### PR TITLE
Revert "Changed to landscape only"

### DIFF
--- a/Logging/Resources/Info.plist
+++ b/Logging/Resources/Info.plist
@@ -71,8 +71,10 @@
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
+		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>


### PR DESCRIPTION
iPad requires both portrait and landscaping for multi-tasking

Reverts airmencoders/Logging-iOS#80