### PR TITLE
Close Bug PR-210 in prep to fix PR-209

### DIFF
--- a/Logging/Controllers/View Controllers/Form 781/Form781ViewController.swift
+++ b/Logging/Controllers/View Controllers/Form 781/Form781ViewController.swift
@@ -101,7 +101,7 @@ class Form781ViewController: UIViewController {
     }
         
     @IBAction func printButtonTapped(_ sender: UIButton) {
-        Helper.printFormFunc()
+        Helper.print871()
     }
     
 } //End

--- a/Logging/Controllers/View Controllers/General/OverviewViewController.swift
+++ b/Logging/Controllers/View Controllers/General/OverviewViewController.swift
@@ -23,7 +23,7 @@ class OverviewViewController: UIViewController {
     }
     
     @IBAction func printButtonTapped(_ sender: UIButton) {
-        Helper.printFormFunc()
+        Helper.print871()
     }
     
     /*

--- a/Logging/HelperFiles/ImageGenerator.swift
+++ b/Logging/HelperFiles/ImageGenerator.swift
@@ -16,7 +16,7 @@ class ImageGenerator {
     /// Returns nil when if the form can not be generated
     static func generateFilledFormPageOneImage(from form: Form781) -> UIImage? {
         
-        let renderer = UIGraphicsImageRenderer(size: CGSize(width: Helper.WIDTH, height: Helper.HEIGHT))
+        let renderer = UIGraphicsImageRenderer(size: Helper.LETTER_SIZE)
         
         let img = renderer.image { ctx in
             // MARK: - AFTO 781 Section I. Mission Data
@@ -139,16 +139,15 @@ class ImageGenerator {
      
      throughout the function, any hard coded numbers represent pixels on the underlay image.  We use an NSAttributedString which gives the ability to control the font size.  Then we use the draw function to position it on the page.
      */
-    static func generateBackOfForm() -> UIImage? {
+    static func generateFilledFormPageTwoImage(from form: Form781) -> UIImage? {
         
-        let renderer = UIGraphicsImageRenderer(size: CGSize(width: Helper.WIDTH, height: Helper.HEIGHT))
+        let renderer = UIGraphicsImageRenderer(size: Helper.LETTER_SIZE)
         
         let backOfForm = renderer.image { ctx in
             
-            // MARK: - Crew finsihing
-            let form = Form781Controller.shared.getCurrentForm()
+            // MARK: - Crew finishing
             
-            let crewSize:Int = (form?.crewMembers.count)!
+            let crewSize: Int = form.crewMembers.count
             
             if crewSize >= 15 {
                 
@@ -158,10 +157,7 @@ class ImageGenerator {
                 
                 for i in 0...remainingCrew {
                     
-                    guard let member = form?.crewMembers[i] else {
-                        continue
-                        
-                    }
+                    let member = form.crewMembers[i]
                     
                     member.flyingOrigin.drawIn(         CGRect(x: 310,  y: 705 + (i * 60), width: 100,  height: height))
                     member.ssnLast4.drawIn(             CGRect(x: 450,  y: 705 + (i * 60), width: 100,  height: height))


### PR DESCRIPTION
Form data drawing front and back were being called twice because the function that generated the front OR back of form was generating the front AND back of form.
Refactored all the functions in the process of  form drawing and form image generation, to make it easier to write test cases.
The decomposed functions might be useful for other forms later?
Rewrote the print function to use a pdf instead of images and html, so we don't have the extra maintenance but with the same output.
Changed Helper.WIDTH / Helper.HEIGHT to Helper.LETTER_SIZE CGSize to decrease verbosity.